### PR TITLE
[Hotfix] Replace a literal string by constant variable at database users table creation.

### DIFF
--- a/database_users_table_util/database_users_table_util.go
+++ b/database_users_table_util/database_users_table_util.go
@@ -36,7 +36,7 @@ const (
 
 // CreateTableIfNotExists creates table `users`.
 func CreateTableIfNotExists(databasePtr *sql.DB) error {
-	_, createTableError := databasePtr.Exec("CREATE TABLE IF NOT EXISTS users" +
+	_, createTableError := databasePtr.Exec("CREATE TABLE IF NOT EXISTS " + TableName +
 		"(" +
 		MailColumnName + "			VARCHAR(320)	NOT NULL," +
 		PasswordColumnName + "		VARCHAR(30)		NOT NULL," +


### PR DESCRIPTION
Replaced the literal string `users` of the query creating the users table by the constant `TableName`.