### PR TITLE
[Hotfix] Fix error occurred when deleting product.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -112,7 +112,9 @@ func createDatabaseOrderItemTableIfNotExists(databasePtr *sql.DB) {
 		OrderItemQuantity + "				INTEGER			NOT NULL,\n" +
 		"PRIMARY KEY(" + OrderItemCartIdColumnName + ", " + OrderItemProductIdColumnName + "),\n" +
 		"FOREIGN KEY(" + OrderItemCartIdColumnName + ") REFERENCES " + CartTableName + "(" + CartIdColumnName + "),\n" +
-		"FOREIGN KEY(" + OrderItemProductIdColumnName + ") REFERENCES " + ProductTableName + "(" + ProductIdColumnName + "));")
+		"FOREIGN KEY(" + OrderItemProductIdColumnName + ") REFERENCES " + ProductTableName + "(" + ProductIdColumnName + ")\n" +
+		"	ON DELETE CASCADE" +
+		");")
 	panicCreateTableError(createTableError)
 }
 


### PR DESCRIPTION
Fixed delete product API that causes error 1451: Cannot delete or update a parent row: a foreign key constaint fails by adding `ON DELETE CASCADE` condition for the foreign key constraint of order item.