### PR TITLE
[Hotfix] Fix database products table constant.

### DIFF
--- a/database/database_constant.go
+++ b/database/database_constant.go
@@ -11,19 +11,19 @@ const (
 )
 
 const (
-	ProductTableName               = "product"
-	ProductIdColumnName            = database_products_table_util.IdColumnName
-	ProductStaffUserNameColumnName = "StaffUserName"
-	ProductDescriptionColumnName   = "Description"
-	ProductNameColumnName          = "Pname"
-	ProductCategoryColumnName      = "Category"
-	ProductSourceColumnName        = "Source"
-	ProductPriceColumnName         = "Price"
-	ProductInventoryColumnName     = "Inventory"
-	ProductSoldQuantityColumnName  = "SoldQuantity"
-	ProductOnSaleDateColumnName    = "OnSaleDate"
-	ProductImageSourceColumnName   = "ImageSrc"
-	productDiscountPolicyCodeColumnName = "SpecialEventDiscountPolicyCode"
+	ProductTableName                    = database_products_table_util.TableName
+	ProductIdColumnName                 = database_products_table_util.IdColumnName
+	ProductStaffUserNameColumnName      = "StaffUserName"
+	ProductDescriptionColumnName        = "Description"
+	ProductNameColumnName               = "Pname"
+	ProductCategoryColumnName           = "Category"
+	ProductSourceColumnName             = "Source"
+	ProductPriceColumnName              = "Price"
+	ProductInventoryColumnName          = "Inventory"
+	ProductSoldQuantityColumnName       = "SoldQuantity"
+	ProductOnSaleDateColumnName         = "OnSaleDate"
+	ProductImageSourceColumnName        = "ImageSrc"
+	productDiscountPolicyCodeColumnName = database_products_table_util.SpecialEventDiscountPolicyCodeColumnName
 )
 
 const (


### PR DESCRIPTION
Utilize constants defined in package `database_products_table_util` for those defined in package `database`, to avoid possible conflict in the future.